### PR TITLE
Multi-System Configuration

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -4,7 +4,7 @@
   nix.settings.experimental-features = "nix-command flakes";
   system.configurationRevision = null; # Will be set from flake
   system.stateVersion = 5;
-  nix.enable = false; # We are using determinate nix, so we want this false
+  nix.enable = false; # Determinate Nix needs false so it manages system
   nixpkgs.hostPlatform = "aarch64-darwin";
 
   # Use nvim configuration from nixvim module

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,0 +1,43 @@
+{ pkgs, ... }: {
+  imports = [ ./nixvim ];
+
+  environment.systemPackages = [
+    pkgs.vim
+    pkgs.tmux
+  ];
+
+  programs.nixvim.enable = true;
+
+  nix.settings.experimental-features = "nix-command flakes";
+
+  system.configurationRevision = null; # Will be set from flake
+  system.stateVersion = 5;
+  nix.enable = false;
+  nixpkgs.hostPlatform = "aarch64-darwin";
+
+  system.defaults.menuExtraClock.Show24Hour = true;
+  system.defaults.controlcenter.BatteryShowPercentage = true;
+
+  system.defaults.dock.autohide = true;
+  system.defaults.dock.autohide-time-modifier = 0.15;
+
+  system.defaults.finder = {
+    ShowPathbar = true;
+    ShowStatusBar = true;
+    _FXSortFoldersFirst = true;
+    CreateDesktop = false;
+    FXDefaultSearchScope = "SCcf";
+    FXRemoveOldTrashItems = true;
+    FXPreferredViewStyle = "clmv";
+  };
+
+  system.defaults.CustomUserPreferences = {
+    "com.apple.screencapture" = {
+      location = "/private/tmp";
+      type = "png";
+    };
+    "org.gpgtools.common" = {
+      "UseKeychain" = "NO";
+    };
+  };
+}

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,21 +1,25 @@
 { pkgs, ... }: {
-  imports = [ ./nixvim ];
 
-  programs.nixvim.enable = true;
-
+  # Standard nix configuration stuff
   nix.settings.experimental-features = "nix-command flakes";
-
   system.configurationRevision = null; # Will be set from flake
   system.stateVersion = 5;
-  nix.enable = false;
+  nix.enable = false; # We are using determinate nix, so we want this false
   nixpkgs.hostPlatform = "aarch64-darwin";
 
+  # Use nvim configuration from nixvim module
+  imports = [ ./nixvim ];
+  programs.nixvim.enable = true;
+
+  # Menubar Settings
   system.defaults.menuExtraClock.Show24Hour = true;
   system.defaults.controlcenter.BatteryShowPercentage = true;
 
-  system.defaults.dock.autohide = true;
-  system.defaults.dock.autohide-time-modifier = 0.15;
+  # Dock Settings
+  # Nix version of this command: defaults write com.apple.dock autohide-delay -float 0; killall Dock
+  #system.defaults.dock.autohide-delay = 0;
 
+  # Finder Settings
   system.defaults.finder = {
     ShowPathbar = true;
     ShowStatusBar = true;
@@ -25,12 +29,15 @@
     FXRemoveOldTrashItems = true;
     FXPreferredViewStyle = "clmv";
   };
-
+  
+  # Other misc preferences
   system.defaults.CustomUserPreferences = {
+    # # Screenshots to /tmp
     "com.apple.screencapture" = {
       location = "/private/tmp";
       type = "png";
     };
+    # Disable pinentry save to keychain
     "org.gpgtools.common" = {
       "UseKeychain" = "NO";
     };

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,11 +1,6 @@
 { pkgs, ... }: {
   imports = [ ./nixvim ];
 
-  environment.systemPackages = [
-    pkgs.vim
-    pkgs.tmux
-  ];
-
   programs.nixvim.enable = true;
 
   nix.settings.experimental-features = "nix-command flakes";

--- a/configuration.nix
+++ b/configuration.nix
@@ -23,10 +23,15 @@
   system.defaults.finder = {
     ShowPathbar = true;
     ShowStatusBar = true;
+    ## Show folders before other files when sorting by name
     _FXSortFoldersFirst = true;
+    ## Hide desktop icons
     CreateDesktop = false;
+    ## Set default search scope to current folder
     FXDefaultSearchScope = "SCcf";
+    ## Remove trash after 30 days
     FXRemoveOldTrashItems = true;
+    ## Set Finder to column view default
     FXPreferredViewStyle = "clmv";
   };
   

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,13 @@
         nixvim.nixDarwinModules.nixvim # Import NixVim module
       ];
     };
+    darwinConfigurations."synnax" = nix-darwin.lib.darwinSystem {
+      modules = [
+        configuration
+        gehenna
+        nixvim.nixDarwinModules.nixvim # Import NixVim module
+      ];
+    };
     darwinConfigurations."gehenna" = nix-darwin.lib.darwinSystem {
       modules = [
         configuration

--- a/flake.nix
+++ b/flake.nix
@@ -12,80 +12,22 @@
 
   outputs = inputs@{ self, nix-darwin, nixpkgs, nixvim }:
   let
-    configuration = { pkgs, ... }: {
-      imports = [ ./nixvim ];
-      # Install system packages
-      environment.systemPackages = [
-        pkgs.vim
-        pkgs.tmux
-      ];
-
-      # Enable NixVim
-      programs.nixvim.enable = true;
-
-      # Homebrew setup
-      homebrew = {
-        enable = true;
-        onActivation.cleanup = "zap";
-        taps = [];
-        brews = [ "cowsay" "rsync" "gnupg" "pinentry-mac" "grep" "koekeishiya/formulae/yabai" "koekeishiya/formulae/skhd" ];
-        casks = [ "kitty" "mpv" "gimp" ];
-      };
-
-      # User shell
-      users.users."neon".shell = pkgs.bashInteractive;
-
-      # Enable flakes
-      nix.settings.experimental-features = "nix-command flakes";
-
-      # Darwin system settings
-      system.configurationRevision = self.rev or self.dirtyRev or null;
-      system.stateVersion = 5;
-      nix.enable = false;
-      nixpkgs.hostPlatform = "aarch64-darwin";
-      
-      networking.hostName = "paradiso";
-      system.defaults.menuExtraClock.Show24Hour = true;
-      system.defaults.controlcenter.BatteryShowPercentage = true;
-
-      # Dock settings
-      system.defaults.dock.autohide = true;
-      # Nix version of this command: defaults write com.apple.dock autohide-time-modifier -float 0.15; killall Dock
-      system.defaults.dock.autohide-time-modifier = 0.15;
-
-      # Finder settings
-      system.defaults.finder.ShowPathbar = true;
-      system.defaults.finder.ShowStatusBar = true;
-      ## Show folders before other files when sorting by name
-      system.defaults.finder._FXSortFoldersFirst = true;
-      ## Hide desktop icons
-      system.defaults.finder.CreateDesktop = false;
-      ## Set default search scope to current folder
-      system.defaults.finder.FXDefaultSearchScope = "SCcf";
-      ## Remove trash after 30 days
-      system.defaults.finder.FXRemoveOldTrashItems = true;
-      ## Set Finder to column view default
-      system.defaults.finder.FXPreferredViewStyle = "clmv";
-
-      # Other misc preferences
-      system.defaults.CustomUserPreferences = {
-        # Screenshots to /tmp
-        "com.apple.screencapture" = {
-          location = "/private/tmp";
-          type = "png";
-        };
-        # Disable pinentry save to keychain
-        "org.gpgtools.common" = {
-          "UseKeychain" = "NO";
-        };
-      };
-
-    };
+    configuration = import ./configuration.nix;
+    paradiso = import ./systems/paradiso.nix;
+    gehenna = import ./systems/gehenna.nix;
   in
   {
     darwinConfigurations."paradiso" = nix-darwin.lib.darwinSystem {
       modules = [
         configuration
+        paradiso
+        nixvim.nixDarwinModules.nixvim # Import NixVim module
+      ];
+    };
+    darwinConfigurations."gehenna" = nix-darwin.lib.darwinSystem {
+      modules = [
+        configuration
+        gehenna
         nixvim.nixDarwinModules.nixvim # Import NixVim module
       ];
     };

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
     configuration = import ./configuration.nix;
     paradiso = import ./systems/paradiso.nix;
     gehenna = import ./systems/gehenna.nix;
+    synnax = import ./systems/synnax.nix;
   in
   {
     darwinConfigurations."paradiso" = nix-darwin.lib.darwinSystem {

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
     darwinConfigurations."synnax" = nix-darwin.lib.darwinSystem {
       modules = [
         configuration
-        gehenna
+        synnax
         nixvim.nixDarwinModules.nixvim # Import NixVim module
       ];
     };

--- a/systems/gehenna.nix
+++ b/systems/gehenna.nix
@@ -6,16 +6,16 @@
     pkgs.rclone
     pkgs.p7zip
     pkgs.ncdu
-  ]; 
+  ];
 
   homebrew = {
     enable = true;
     onActivation.cleanup = "zap";
     taps = [ "koekeishiya/formulae" ]; # koekeishiya tap needed for yabai and skhd
     brews = [ "cowsay" "rsync" "gnupg" "pinentry-mac" "grep" "yabai" "skhd" ];
-    casks = [ "kitty" "mpv" "gimp" ];
+    casks = [ "kitty" "mpv" "gimp" "keepassxc" "element" "karabiner-elements" "macfuse" "chromium" "orbstack" ];
   };
 
-  users.users."neon".shell = pkgs.bashInteractive;
-  networking.hostName = "paradiso";
+  users.users."xue".shell = pkgs.bashInteractive;
+  networking.hostName = "gehenna";
 }

--- a/systems/paradiso.nix
+++ b/systems/paradiso.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }: {
+  homebrew = {
+    enable = true;
+    onActivation.cleanup = "zap";
+    taps = [];
+    brews = [ "cowsay" "rsync" "gnupg" "pinentry-mac" "grep" "koekeishiya/formulae/yabai" "koekeishiya/formulae/skhd" ];
+    casks = [ "kitty" "mpv" "gimp" ];
+  };
+
+  users.users."neon".shell = pkgs.bashInteractive;
+  networking.hostName = "paradiso";
+}

--- a/systems/synnax.nix
+++ b/systems/synnax.nix
@@ -6,16 +6,16 @@
     pkgs.rclone
     pkgs.p7zip
     pkgs.ncdu
-  ]; 
+  ];
 
   homebrew = {
     enable = true;
     onActivation.cleanup = "zap";
     taps = [ "koekeishiya/formulae" ]; # koekeishiya tap needed for yabai and skhd
     brews = [ "cowsay" "rsync" "gnupg" "pinentry-mac" "grep" "yabai" "skhd" ];
-    casks = [ "kitty" "mpv" "gimp" ];
+    casks = [ "kitty" "mpv" "gimp" "keepassxc" "element" "karabiner-elements" "macfuse" "chromium" "orbstack" ];
   };
 
-  users.users."neon".shell = pkgs.bashInteractive;
-  networking.hostName = "paradiso";
+  users.users."xue".shell = pkgs.bashInteractive;
+  networking.hostName = "synnax";
 }


### PR DESCRIPTION
Splits base configuration module and system-specific configurations to individual modules stored within their own files.

- Base configuration now lives in `/configuration.nix` rather than inline in `flake.nix`.
- System-specific configuration lives in `systems/SYSTEMNAME.nix`
- Nix automatically chooses which system to build based on device name